### PR TITLE
changing working_dir; using runner

### DIFF
--- a/testkraken/testrunner.py
+++ b/testkraken/testrunner.py
@@ -8,5 +8,5 @@ def runner(workflow_dir):
     print("Workflow Name: {}".format(os.path.basename(workflow_dir)))
     wf = WorkflowRegtest(workflow_dir)
     wf.run()
-    wf.merging_all_output()
+    wf.merge_outputs()
     wf.dashboard_workflow()

--- a/testkraken/tests/test_basic_examples.py
+++ b/testkraken/tests/test_basic_examples.py
@@ -1,7 +1,7 @@
 import os, pdb
 import pytest
 
-from testkraken.workflowregtest import WorkflowRegtest
+from testkraken.testrunner import runner
 
 Workflows_main_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                 "../../workflows4regtests", "basic_examples",)
@@ -11,10 +11,7 @@ workflows_list = [os.path.join(Workflows_main_dir, workf) for workf in next(os.w
 def test_basic_examples(workflow_dir):
     print(workflow_dir)
     try:
-        wf = WorkflowRegtest(workflow_dir)
-        wf.run()
-        wf.merge_outputs()
-        wf.dashboard_workflow()
+        runner(workflow_dir)
     except Exception as e:
         print(e)
         assert False

--- a/testkraken/workflowregtest.py
+++ b/testkraken/workflowregtest.py
@@ -24,6 +24,8 @@ class WorkflowRegtest:
     ----------
     workflow_path: Path-like, directory of workflow.
     working_dir: Path-like, working directory, temporary directory by default.
+    tmp_working_dir: Boolean value, if working_dir not provided,
+        a temporary directory will be created if True
 
     Attributes
     ----------
@@ -38,15 +40,21 @@ class WorkflowRegtest:
     nenv: int, number of environments.
     """
 
-    def __init__(self, workflow_path, working_dir=None):
+    def __init__(self, workflow_path, working_dir=None, tmp_working_dir=False):
         self.workflow_path = Path(workflow_path).absolute()
-        if working_dir is None:
+        if working_dir and tmp_working_dir:
+            raise Exception("please provide working_dir OR set tmp_working_dir=True, "
+                            "do not change both arguments")
+        elif tmp_working_dir:
             self.working_dir = Path(tempfile.mkdtemp(
             prefix='testkraken-{}'.format(self.workflow_path.name))).absolute()
-        else:
+        elif working_dir:
             self.working_dir = Path(working_dir).absolute()
             self.working_dir.mkdir(parents=True, exist_ok=True)
-
+        else:
+            # if working_dir is None and tmp_working_dir == False
+            self.working_dir = (Path.cwd() / (self.workflow_path.name + "_cwl")).absolute()
+            self.working_dir.mkdir(exist_ok=True)
         _validate_workflow_path(self.workflow_path)
 
         with (self.workflow_path / 'parameters.yaml').open() as f:


### PR DESCRIPTION
* I've changed the default behavior of `workking_dir`, we can still change it, but I really believe it should not be a temporary one

* I moved back to the `runner` in test. 